### PR TITLE
Improve dark mode persistence and enrich content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This repository contains a polished portfolio website for **Jamy Fox**. Open `in
 - `ambition.html` – Ambition
 - `contact.html` – Contact
 
-The site uses Google Fonts and modern CSS for a high-end look. A built-in dark mode toggle lets visitors switch themes. Customize the placeholder text with your own details.
+The site uses Google Fonts and modern CSS for a high-end look. A built-in dark mode toggle lets visitors switch themes, and the preference now persists when navigating between pages. Customize the placeholder text with your own details.

--- a/ambition.html
+++ b/ambition.html
@@ -30,6 +30,8 @@
     <main>
         <section class="section">
             <p>Jamy aims to create inclusive digital experiences while continuously sharpening development skills.</p>
+            <p>The next milestone is leading a team focused on accessible design systems and guiding new developers.</p>
+            <p>Staying curious, experimenting with new frameworks and collaborating with creative peers keep the passion alive.</p>
         </section>
     </main>
     <footer class="footer">

--- a/contact.html
+++ b/contact.html
@@ -35,6 +35,10 @@
                 <textarea placeholder="Hi Jamy, I..." required></textarea>
                 <button type="submit" class="btn">Send</button>
             </form>
+            <div class="contact-details">
+                <p>Email: <a href="mailto:jamy@example.com">jamy@example.com</a></p>
+                <p>LinkedIn: <a href="https://www.linkedin.com/in/jamyfox">linkedin.com/in/jamyfox</a></p>
+            </div>
         </section>
     </main>
     <footer class="footer">

--- a/index.html
+++ b/index.html
@@ -36,6 +36,15 @@
                 <p>Jamy has collaborated with cross‑functional teams on a variety of web and mobile projects, always focusing on usability and performance.</p>
             </div>
         </section>
+        <section class="section light">
+            <h2>Experience</h2>
+            <p>With over five years in the industry, Jamy has built everything from interactive prototypes to full‑fledged production apps.</p>
+            <p>Collaborations span boutique agencies to global consultancies, delivering clean code and thoughtful design.</p>
+        </section>
+        <section class="section">
+            <h2>Education</h2>
+            <p>A background in graphic design informs every project, blending aesthetics with modern development practices.</p>
+        </section>
     </main>
     <footer class="footer">
         <p>&copy; 2024 Jamy Fox. All rights reserved.</p>

--- a/projects.html
+++ b/projects.html
@@ -43,6 +43,18 @@
                     <img src="https://images.unsplash.com/photo-1504805572947-34fad45aed93?auto=format&fit=crop&w=600&q=60" alt="Marketing Website">
                     <h3>Marketing Website</h3>
                 </div>
+                <div class="project-card">
+                    <img src="https://images.unsplash.com/photo-1556157382-97eda2d62296?auto=format&fit=crop&w=600&q=60" alt="Real Estate Portal">
+                    <h3>Real Estate Portal</h3>
+                </div>
+                <div class="project-card">
+                    <img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=600&q=60" alt="Analytics App">
+                    <h3>Analytics App</h3>
+                </div>
+                <div class="project-card">
+                    <img src="https://images.unsplash.com/photo-1532619043317-48d1d03bdc1f?auto=format&fit=crop&w=600&q=60" alt="Event Platform">
+                    <h3>Event Platform</h3>
+                </div>
             </div>
         </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -10,11 +10,19 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // Apply stored theme preference on load
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+    }
+
     // Theme toggle
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark');
+            const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
+            localStorage.setItem('theme', theme);
         });
     }
 });

--- a/skills.html
+++ b/skills.html
@@ -36,6 +36,8 @@
                 <li>Node.js</li>
                 <li>UI/UX Design</li>
             </ul>
+            <p>Version control with Git keeps projects organized, while build tools like Webpack streamline deployment.</p>
+            <p>Jamy also relies on Figma and Sketch to translate concepts into polished interfaces and accessible user flows.</p>
         </section>
     </main>
     <footer class="footer">

--- a/style.css
+++ b/style.css
@@ -193,3 +193,13 @@ body.dark {
 .accent {
     color: #ffd166;
 }
+
+.contact-details {
+    margin-top: 1.5rem;
+    text-align: center;
+}
+
+.contact-details a {
+    color: inherit;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- preserve theme selection with localStorage
- expand details on About, Skills, Projects, Ambition and Contact pages
- document theme persistence in README
- style contact detail section

## Testing
- `node -v`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_684035e73ec483299ff64a7d89e75dda