### PR TITLE
Add FAQ page with collapsible answers and theme toggle icon update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This repository contains a polished portfolio website for **Jamy Fox**. Open `in
 - `projects.html` – Projects
 - `ambition.html` – Ambition
 - `contact.html` – Contact
+- `faq.html` – Frequently Asked Questions
 
 The site uses Google Fonts and modern CSS for a high-end look. A built-in dark mode toggle lets visitors switch themes, and the preference now persists when navigating between pages. Customize the placeholder text with your own details.

--- a/ambition.html
+++ b/ambition.html
@@ -19,6 +19,7 @@
                 <li><a href="projects.html">Projects</a></li>
                 <li><a href="ambition.html">Ambition</a></li>
                 <li><a href="contact.html">Contact</a></li>
+                <li><a href="faq.html">FAQ</a></li>
             </ul>
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#127769;</button>
         </nav>

--- a/faq.html
+++ b/faq.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - Jamy Fox</title>
+    <title>FAQ - Jamy Fox</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
@@ -24,21 +24,25 @@
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#127769;</button>
         </nav>
         <div class="hero-content">
-            <h1>Contact</h1>
-            <p>Jamy is always happy to talk shop. Drop a note below.</p>
+            <h1>FAQ</h1>
+            <p>Answers to some common questions about Jamy's work.</p>
         </div>
     </header>
     <main>
         <section class="section">
-            <form class="contact-form" onsubmit="return false;">
-                <input type="text" placeholder="Your name" required>
-                <input type="email" placeholder="you@example.com" required>
-                <textarea placeholder="Hi Jamy, I..." required></textarea>
-                <button type="submit" class="btn">Send</button>
-            </form>
-            <div class="contact-details">
-                <p>Email: <a href="mailto:stanvangoor@live.nl">stanvangoor@live.nl</a></p>
-                <p>LinkedIn: <a href="https://www.linkedin.com/in/jamyfox">linkedin.com/in/jamyfox</a></p>
+            <div class="faq">
+                <details>
+                    <summary>What services do you offer?</summary>
+                    <p>I specialize in front-end development, UI/UX design, and accessibility audits.</p>
+                </details>
+                <details>
+                    <summary>Where are you located?</summary>
+                    <p>I'm based in Amsterdam but collaborate with clients worldwide.</p>
+                </details>
+                <details>
+                    <summary>How can we start a project together?</summary>
+                    <p>Reach out via the contact page with details about your idea and I'll get in touch.</p>
+                </details>
             </div>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
                 <li><a href="projects.html">Projects</a></li>
                 <li><a href="ambition.html">Ambition</a></li>
                 <li><a href="contact.html">Contact</a></li>
+                <li><a href="faq.html">FAQ</a></li>
             </ul>
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#127769;</button>
         </nav>

--- a/projects.html
+++ b/projects.html
@@ -19,6 +19,7 @@
                 <li><a href="projects.html">Projects</a></li>
                 <li><a href="ambition.html">Ambition</a></li>
                 <li><a href="contact.html">Contact</a></li>
+                <li><a href="faq.html">FAQ</a></li>
             </ul>
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#127769;</button>
         </nav>

--- a/script.js
+++ b/script.js
@@ -16,13 +16,23 @@ document.addEventListener('DOMContentLoaded', () => {
         document.body.classList.add('dark');
     }
 
+    function updateIcon() {
+        if (document.body.classList.contains('dark')) {
+            themeToggle.textContent = '☀️';
+        } else {
+            themeToggle.textContent = '🌙';
+        }
+    }
+
     // Theme toggle
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
+        updateIcon();
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark');
             const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
             localStorage.setItem('theme', theme);
+            updateIcon();
         });
     }
 });

--- a/skills.html
+++ b/skills.html
@@ -19,6 +19,7 @@
                 <li><a href="projects.html">Projects</a></li>
                 <li><a href="ambition.html">Ambition</a></li>
                 <li><a href="contact.html">Contact</a></li>
+                <li><a href="faq.html">FAQ</a></li>
             </ul>
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">&#127769;</button>
         </nav>

--- a/style.css
+++ b/style.css
@@ -203,3 +203,13 @@ body.dark {
     color: inherit;
     text-decoration: none;
 }
+
+.faq details {
+    margin-bottom: 1rem;
+}
+
+.faq summary {
+    cursor: pointer;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add a new `faq.html` page with collapsible questions
- link to FAQ from all navigation menus
- update theme toggle to show a sun icon when dark mode is active
- style FAQ section
- document FAQ page in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405acae08c832986ea443f5a11bbad