### PR TITLE
Add skill logos and premium icons

### DIFF
--- a/skills.html
+++ b/skills.html
@@ -11,6 +11,17 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      integrity="sha512-ugrSCP0sY1koRaSPoaqe7i0rGUNShUMHbOWcZH/5LiCFYI8aAkaI0s5momkGLumZ5qX6Ch12HaxJXhMlbL/6nw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/devicon@2.15.1/devicon.min.css"
+    />
   </head>
   <body>
     <header class="hero">
@@ -57,33 +68,33 @@
           </div>
           <div class="switcher-content">
             <div class="skill-panel active" data-skill="tech">
-              <div class="icon" aria-hidden="true">💻</div>
+              <div class="icon" aria-hidden="true"><i class="fa-solid fa-laptop-code"></i></div>
               <ul class="skills-list">
-                <li>HTML &amp; CSS</li>
-                <li>JavaScript &amp; Node.js</li>
-                <li>React (component-based)</li>
-                <li>Git &amp; version control</li>
-                <li>Build tools (Webpack &amp; Vite)</li>
-                <li>API integrations (Meta, LinkedIn, Google Ads)</li>
-                <li>MySQL &amp; Python scraping</li>
+                <li><i class="devicon-html5-plain colored"></i><i class="devicon-css3-plain colored"></i> HTML &amp; CSS</li>
+                <li><i class="devicon-javascript-plain colored"></i><i class="devicon-nodejs-plain colored"></i> JavaScript &amp; Node.js</li>
+                <li><i class="devicon-react-original colored"></i> React (component-based)</li>
+                <li><i class="devicon-git-plain colored"></i> Git &amp; version control</li>
+                <li><i class="devicon-webpack-plain colored"></i><i class="devicon-vitejs-plain colored"></i> Build tools (Webpack &amp; Vite)</li>
+                <li><i class="fa-solid fa-plug"></i> API integrations (Meta, LinkedIn, Google Ads)</li>
+                <li><i class="devicon-python-plain colored"></i><i class="devicon-mysql-plain colored"></i> MySQL &amp; Python scraping</li>
               </ul>
             </div>
             <div class="skill-panel" data-skill="design">
-              <div class="icon" aria-hidden="true">🎨</div>
+              <div class="icon" aria-hidden="true"><i class="fa-solid fa-palette"></i></div>
               <ul class="skills-list">
-                <li>UI/UX fundamentals</li>
-                <li>Figma &amp; Sketch workflows</li>
-                <li>User focused flows</li>
-                <li>Branding meets interaction</li>
+                <li><i class="fa-solid fa-pencil-ruler"></i> UI/UX fundamentals</li>
+                <li><i class="devicon-figma-plain colored"></i> Figma &amp; Sketch workflows</li>
+                <li><i class="fa-solid fa-route"></i> User focused flows</li>
+                <li><i class="fa-regular fa-lightbulb"></i> Branding meets interaction</li>
               </ul>
             </div>
             <div class="skill-panel" data-skill="strategy">
-              <div class="icon" aria-hidden="true">📊</div>
+              <div class="icon" aria-hidden="true"><i class="fa-solid fa-chart-line"></i></div>
               <ul class="skills-list">
-                <li>Marketing data analysis</li>
-                <li>Power BI &amp; Looker Studio</li>
-                <li>Dashboard building &amp; KPIs</li>
-                <li>Tech strength with brand strategy</li>
+                <li><i class="fa-solid fa-chart-bar"></i> Marketing data analysis</li>
+                <li><i class="fa-solid fa-chart-pie"></i> Power BI &amp; Looker Studio</li>
+                <li><i class="fa-solid fa-gauge-high"></i> Dashboard building &amp; KPIs</li>
+                <li><i class="fa-solid fa-bullseye"></i> Tech strength with brand strategy</li>
               </ul>
             </div>
           </div>

--- a/style.css
+++ b/style.css
@@ -156,6 +156,16 @@ a:visited {
   margin-top: 1rem;
 }
 
+.skills-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.skills-list i {
+  font-size: 1.2rem;
+}
+
 .project-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -363,6 +373,7 @@ a:visited {
 }
 
 .skill-panel .icon {
-  font-size: 2rem;
+  font-size: 2.5rem;
   margin-bottom: 1rem;
+  color: #ffbf00;
 }


### PR DESCRIPTION
## Summary
- enhance the skills page with Font Awesome & Devicon icons
- show icons for every individual skill
- update styling for new icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840702f43608329a0136652d4238e79