### PR TITLE
Darken header overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,7 +95,7 @@ a:visited {
 
 .hero {
   background:
-    linear-gradient(rgba(255, 255, 0, 0.3), rgba(255, 255, 0, 0.3)),
+    linear-gradient(rgba(196, 160, 96, 0.7), rgba(196, 160, 96, 0.7)),
     url("https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?auto=format&fit=crop&w=1500&q=80")
       center/cover no-repeat;
   color: #fff;


### PR DESCRIPTION
## Summary
- darken the hero section gradient so white text stands out

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6841473db2588329bc50b2ae83f5717d