### PR TITLE
Enhance landing page UX and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,26 +49,28 @@
           translates data into strategic insights and thrives where data,
           branding and content meet.
         </p>
-        <a href="contact.html" class="btn" data-i18n="index-cta"
-          >Request Consultation</a
-        >
+        <a href="contact.html" class="btn" data-i18n="index-cta">Request Consultation</a>
       </div>
+      <div class="scroll-indicator">Scroll &#8595;</div>
     </header>
     <main>
-      <section class="section profile">
-        <img
-          src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY"
-          alt="Portrait of Stan van Goor"
-          class="profile-img"
-        />
-        <div>
-          <h2 data-i18n="biography-heading">Biography</h2>
-          <p data-i18n="biography-text">
-            Driven by curiosity, Stan links numbers to narratives. He enjoys
-            discovering how data can strengthen a brand and is a self‑starter
-            who turns insights into action.
-          </p>
-        </div>
+      <section class="section menu-grid">
+        <a href="projects.html" class="menu-item" style="--bg:#ff6868">
+          <h3>Projects</h3>
+          <p class="menu-desc">Case studies and work samples</p>
+        </a>
+        <a href="skills.html" class="menu-item" style="--bg:#68b0ff">
+          <h3>Skills</h3>
+          <p class="menu-desc">Overview of technologies</p>
+        </a>
+        <a href="ambition.html" class="menu-item" style="--bg:#ffd166">
+          <h3>Ambition</h3>
+          <p class="menu-desc">Goals and motivation</p>
+        </a>
+        <a href="contact.html" class="menu-item" style="--bg:#8ae665">
+          <h3>Contact</h3>
+          <p class="menu-desc">Get in touch</p>
+        </a>
       </section>
       <section class="section light">
         <h2 data-i18n="experience-heading">Experience</h2>

--- a/style.css
+++ b/style.css
@@ -62,9 +62,19 @@ a:visited {
 }
 
 .navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
   display: flex;
   align-items: center;
   padding: 1rem 2rem;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+}
+.dark .navbar {
+  background-color: rgba(0, 0, 0, 0.9);
 }
 
 .nav-links {
@@ -106,6 +116,14 @@ a:visited {
 .hero .logo {
   color: #fff;
 }
+.navbar .logo,
+.navbar .nav-links a {
+  color: #333;
+}
+.dark .navbar .logo,
+.dark .navbar .nav-links a {
+  color: #fff;
+}
 .nav-links a:hover {
   color: var(--accent);
 }
@@ -117,8 +135,12 @@ a:visited {
       center/cover no-repeat;
   color: #fff;
   text-align: center;
-  padding: 6rem 2rem;
+  padding: 8rem 2rem 2rem;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .dark .hero {
@@ -444,4 +466,74 @@ a:visited {
 .reveal.appear {
   opacity: 1;
   transform: none;
+}
+
+/* Scroll indicator */
+.scroll-indicator {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: bounce 2s infinite;
+  font-size: 1rem;
+  color: inherit;
+}
+
+@keyframes bounce {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
+    transform: translateX(-50%) translateY(0);
+  }
+  40% {
+    transform: translateX(-50%) translateY(-10px);
+  }
+  60% {
+    transform: translateX(-50%) translateY(-5px);
+  }
+}
+
+/* Menu grid */
+.menu-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 1rem;
+  padding: 0;
+  min-height: 100vh;
+}
+
+.menu-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  text-align: center;
+  color: #fff;
+  background-color: var(--bg, #666);
+  border-radius: 8px;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+}
+
+.menu-item:hover {
+  transform: translateY(-4px);
+}
+
+.menu-desc {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  opacity: 0;
+  font-size: 0.9rem;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.menu-item:hover .menu-desc {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }


### PR DESCRIPTION
## Summary
- keep navigation fixed to top of page
- center hero content and add subtle scroll indicator
- replace biography section with colorful menu grid
- add styles for the new layout elements

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68414d0c38388329ab572d28dafa318f