### PR TITLE
Improve landing hero and menu hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,12 +152,12 @@ a:visited {
 
 /* Simplified hero for landing page */
 .landing-hero {
-  background-color: #fff;
+  background: #fff;
   color: #000;
 }
 
 .dark .landing-hero {
-  background-color: #000;
+  background: #000;
   color: #fff;
 }
 
@@ -544,11 +544,12 @@ a:visited {
   border-radius: 0;
   text-decoration: none;
   overflow: hidden;
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, filter 0.3s ease-in-out;
 }
 
 .menu-item:hover {
   transform: translateY(-4px);
+  filter: brightness(0.95);
 }
 
 .menu-desc {
@@ -563,6 +564,11 @@ a:visited {
   inset: 0;
   background-color: var(--bg, #666);
   opacity: 0.6;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.menu-item:hover::before {
+  opacity: 0.75;
 }
 
 .menu-item h3,


### PR DESCRIPTION
## Summary
- simplify landing hero header to solid backgrounds
- darken menu blocks on hover

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684151623be883299501b52015c71999