### PR TITLE
Add profile image & update landing styling

### DIFF
--- a/ambition.html
+++ b/ambition.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/analytics-app.html
+++ b/analytics-app.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/contact.html
+++ b/contact.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/enterprise-dashboard.html
+++ b/enterprise-dashboard.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/event-platform.html
+++ b/event-platform.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/faq.html
+++ b/faq.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <body class="snap-scroll">
     <header class="hero landing-hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/marketing-website.html
+++ b/marketing-website.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/mobile-commerce.html
+++ b/mobile-commerce.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/projects.html
+++ b/projects.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/real-estate-portal.html
+++ b/real-estate-portal.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/skills.html
+++ b/skills.html
@@ -30,7 +30,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Stan van Goor</div>
+        <div class="logo"><img src="https://via.placeholder.com/40" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>
           <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>

--- a/style.css
+++ b/style.css
@@ -5,8 +5,8 @@
 }
 
 :root {
-  --accent: #c4a060;
-  --accent-hover: #b18a50;
+  --accent: #FF6B00;
+  --accent-hover: #e65c00;
 }
 
 body {
@@ -128,6 +128,20 @@ a:visited {
   color: var(--accent);
 }
 
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.nav-profile-img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
 .hero {
   background:
     linear-gradient(rgba(196, 160, 96, 0.7), rgba(196, 160, 96, 0.7)),
@@ -175,13 +189,14 @@ a:visited {
 }
 
 .hero-content h1 {
-  font-size: 2.5rem;
+  font-size: 3rem;
   margin-bottom: 1rem;
 }
 
 .hero-content p {
   font-size: 1.25rem;
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem;
+  max-width: 600px;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- include profile image next to name in every navigation bar
- switch accent color to bright orange
- make landing hero heading larger with narrower text

## Testing
- `tidy -errors index.html` *(fails: warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_684152acde8c8329bdb6882248fca986