### PR TITLE
Adjust hero behaviour on scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -245,15 +245,13 @@ document.addEventListener("DOMContentLoaded", () => {
   const landingHero = document.querySelector(".landing-hero");
   const menuGrid = document.querySelector(".menu-grid");
   if (landingHero && menuGrid) {
-    menuGrid.style.transform = "translateY(100px)";
-    menuGrid.style.opacity = "0";
-    menuGrid.style.transition = "transform 0.6s ease, opacity 0.6s ease";
+    menuGrid.style.transform = "translateY(100vh)";
+    menuGrid.style.transition = "transform 0.6s ease";
     window.addEventListener("scroll", () => {
       const heroHeight = landingHero.offsetHeight;
       const ratio = Math.min(window.scrollY / heroHeight, 1);
       landingHero.style.opacity = String(1 - ratio);
-      menuGrid.style.transform = `translateY(${100 * (1 - ratio)}px)`;
-      menuGrid.style.opacity = String(ratio);
+      menuGrid.style.transform = `translateY(${100 * (1 - ratio)}vh)`;
     });
   }
 });

--- a/style.css
+++ b/style.css
@@ -168,6 +168,10 @@ a:visited {
 .landing-hero {
   background: #fff;
   color: #000;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  z-index: 1;
 }
 
 .dark .landing-hero {


### PR DESCRIPTION
## Summary
- keep landing hero fixed with sticky positioning
- revise scroll animation so menu slides up without fading

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68415561a3b48329bf2c6e6102b775d2