### PR TITLE
Fix hero fade transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body class="snap-scroll">
-    <header class="hero landing-hero">
+    <header id="hero" class="hero landing-hero">
       <nav class="navbar">
         <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
         <ul class="nav-links">
@@ -53,8 +53,8 @@
       </div>
       <div class="scroll-indicator">Scroll &#8595;</div>
     </header>
-    <main>
-      <section class="section menu-grid">
+      <main>
+        <section id="menu-blocks" class="section menu-grid">
         <a
           href="projects.html"
           class="menu-item"

--- a/script.js
+++ b/script.js
@@ -241,17 +241,15 @@ document.addEventListener("DOMContentLoaded", () => {
     observer.observe(el);
   });
 
-  // Landing page scroll transition
-  const landingHero = document.querySelector(".landing-hero");
-  const menuGrid = document.querySelector(".menu-grid");
-  if (landingHero && menuGrid) {
-    menuGrid.style.transform = "translateY(100vh)";
-    menuGrid.style.transition = "transform 0.6s ease";
+  // Landing page scroll fade
+  const heroSection = document.getElementById("hero");
+  if (heroSection) {
     window.addEventListener("scroll", () => {
-      const heroHeight = landingHero.offsetHeight;
-      const ratio = Math.min(window.scrollY / heroHeight, 1);
-      landingHero.style.opacity = String(1 - ratio);
-      menuGrid.style.transform = `translateY(${100 * (1 - ratio)}vh)`;
+      const scrollPosition = window.scrollY;
+      const fadeOutEnd = window.innerHeight / 1.5;
+      let opacity = 1 - scrollPosition / fadeOutEnd;
+      if (opacity < 0) opacity = 0;
+      heroSection.style.opacity = opacity.toString();
     });
   }
 });

--- a/style.css
+++ b/style.css
@@ -168,10 +168,13 @@ a:visited {
 .landing-hero {
   background: #fff;
   color: #000;
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  width: 100vw;
   height: 100vh;
-  z-index: 1;
+  z-index: 10;
+  transition: opacity 0.5s ease-out;
 }
 
 .dark .landing-hero {
@@ -546,6 +549,12 @@ a:visited {
   gap: 0;
   padding: 0;
   min-height: 100vh;
+}
+
+#menu-blocks {
+  position: relative;
+  z-index: 5;
+  margin-top: 100vh;
 }
 
 .menu-item {


### PR DESCRIPTION
## Summary
- fade out the hero as the page scrolls
- slide the menu blocks up over the hero

## Testing
- `htmlhint index.html`
- `htmlhint *.html`


------
https://chatgpt.com/codex/tasks/task_e_684156cf75c88329ade8bdafc7aee13e