### PR TITLE
Update hero fade overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,30 +17,30 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body class="snap-scroll">
+    <nav class="navbar">
+      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+      <ul class="nav-links">
+        <li><a href="index.html" data-i18n="nav-about">About me</a></li>
+        <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>
+        <li><a href="projects.html" data-i18n="nav-projects">Projects</a></li>
+        <li><a href="contact.html" data-i18n="nav-contact">Contact</a></li>
+      </ul>
+      <button
+        id="lang-toggle"
+        class="lang-toggle"
+        aria-label="Switch language"
+      >
+        🇳🇱
+      </button>
+      <button
+        id="theme-toggle"
+        class="theme-toggle"
+        aria-label="Toggle theme"
+      >
+        &#127769;
+      </button>
+    </nav>
     <header id="hero" class="hero landing-hero">
-      <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
-        <ul class="nav-links">
-          <li><a href="index.html" data-i18n="nav-about">About me</a></li>
-          <li><a href="skills.html" data-i18n="nav-skills">Skills</a></li>
-          <li><a href="projects.html" data-i18n="nav-projects">Projects</a></li>
-          <li><a href="contact.html" data-i18n="nav-contact">Contact</a></li>
-        </ul>
-        <button
-          id="lang-toggle"
-          class="lang-toggle"
-          aria-label="Switch language"
-        >
-          🇳🇱
-        </button>
-        <button
-          id="theme-toggle"
-          class="theme-toggle"
-          aria-label="Toggle theme"
-        >
-          &#127769;
-        </button>
-      </nav>
       <div class="hero-content">
         <h1 data-i18n="index-title">About Me</h1>
         <p data-i18n="index-subtitle">

--- a/script.js
+++ b/script.js
@@ -236,10 +236,12 @@ document.addEventListener("DOMContentLoaded", () => {
     { threshold: 0.1 },
   );
 
-  document.querySelectorAll(".section, .hero-content").forEach((el) => {
-    el.classList.add("reveal");
-    observer.observe(el);
-  });
+  document
+    .querySelectorAll(".section:not(#menu-blocks), .hero-content")
+    .forEach((el) => {
+      el.classList.add("reveal");
+      observer.observe(el);
+    });
 
   // Landing page scroll fade
   const heroSection = document.getElementById("hero");
@@ -250,6 +252,11 @@ document.addEventListener("DOMContentLoaded", () => {
       let opacity = 1 - scrollPosition / fadeOutEnd;
       if (opacity < 0) opacity = 0;
       heroSection.style.opacity = opacity.toString();
+      if (opacity === 0) {
+        heroSection.classList.add("faded");
+      } else {
+        heroSection.classList.remove("faded");
+      }
     });
   }
 });

--- a/style.css
+++ b/style.css
@@ -177,6 +177,10 @@ a:visited {
   transition: opacity 0.5s ease-out;
 }
 
+.landing-hero.faded {
+  pointer-events: none;
+}
+
 .dark .landing-hero {
   background: #000;
   color: #fff;
@@ -553,7 +557,7 @@ a:visited {
 
 #menu-blocks {
   position: relative;
-  z-index: 5;
+  z-index: 20;
   margin-top: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- keep navbar outside hero so it doesn't fade
- ensure menu blocks layer over hero
- disable reveal animation for menu section
- toggle pointer-events once hero fully faded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841586063148329b49e08ec936f1d6f