### PR TITLE
Add help hints for language and theme toggles

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,6 +31,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Language toggle
   const langToggle = document.getElementById("lang-toggle");
 
+  let langHint;
+  let themeHint;
+
   const translations = {
     nl: {
       "nav-about": "Over mij",
@@ -185,6 +188,12 @@ document.addEventListener("DOMContentLoaded", () => {
   applyTranslations(storedLang);
 
   if (langToggle) {
+    langToggle.setAttribute("title", "Switch language");
+    langHint = document.createElement("span");
+    langHint.id = "lang-hint";
+    langHint.className = "help-hint";
+    langHint.textContent = "\ud83c\udf10";
+    langToggle.after(langHint);
     langToggle.addEventListener("click", () => {
       const newLang =
         (localStorage.getItem("lang") || "en") === "en" ? "nl" : "en";
@@ -196,6 +205,14 @@ document.addEventListener("DOMContentLoaded", () => {
   // Theme toggle
   const themeToggle = document.getElementById("theme-toggle");
   if (themeToggle) {
+    themeToggle.setAttribute("title", "Toggle dark mode");
+    themeHint = document.createElement("span");
+    themeHint.id = "theme-hint";
+    themeHint.className = "help-hint";
+    themeHint.textContent = "\u2600";
+    themeToggle.after(themeHint);
+    themeToggle.classList.add("pulse-once");
+    setTimeout(() => themeToggle.classList.remove("pulse-once"), 3000);
     updateIcon();
     themeToggle.addEventListener("click", () => {
       document.body.classList.toggle("dark");
@@ -204,6 +221,19 @@ document.addEventListener("DOMContentLoaded", () => {
       updateIcon();
     });
   }
+
+  const showHints = () => {
+    langHint?.classList.add("visible");
+    themeHint?.classList.add("visible");
+  };
+  setTimeout(showHints, 2000);
+
+  const hideHints = () => {
+    langHint?.classList.remove("visible");
+    themeHint?.classList.remove("visible");
+  };
+  document.addEventListener("scroll", hideHints, { once: true });
+  document.addEventListener("click", hideHints, { once: true });
 
   // Skill switcher
   const switchButtons = document.querySelectorAll(".switch-btn");

--- a/style.css
+++ b/style.css
@@ -94,6 +94,32 @@ a:visited {
   margin-left: 0.5rem;
 }
 
+.help-hint {
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.help-hint.visible {
+  opacity: 0.7;
+}
+
+.theme-toggle.pulse-once {
+  animation: pulse-glow 1.5s ease-in-out 2;
+}
+
+@keyframes pulse-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--accent);
+  }
+  50% {
+    box-shadow: 0 0 8px 2px var(--accent);
+  }
+}
+
 .lang-toggle {
   border: none;
   background: none;


### PR DESCRIPTION
## Summary
- add new CSS classes for hint text and glow animation
- inject hint elements via script.js
- show hints briefly on load and hide on user interaction

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684166e2b4a88329a62cd60e795daa21