### PR TITLE
Improve mobile navbar layout

### DIFF
--- a/ambition.html
+++ b/ambition.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/analytics-app.html
+++ b/analytics-app.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/contact.html
+++ b/contact.html
@@ -19,7 +19,7 @@
   <body class="snap-scroll">
     <header id="hero" class="hero landing-hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/enterprise-dashboard.html
+++ b/enterprise-dashboard.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/event-platform.html
+++ b/event-platform.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/faq.html
+++ b/faq.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   </head>
   <body class="snap-scroll">
     <nav class="navbar">
-      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
         <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/marketing-website.html
+++ b/marketing-website.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/mobile-commerce.html
+++ b/mobile-commerce.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/projects.html
+++ b/projects.html
@@ -18,7 +18,7 @@
   </head>
   <body class="snap-scroll">
     <nav class="navbar">
-      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
         <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/real-estate-portal.html
+++ b/real-estate-portal.html
@@ -19,7 +19,7 @@
   <body>
     <header class="hero">
       <nav class="navbar">
-        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+        <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
         <ul class="nav-links">
           <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/skills.html
+++ b/skills.html
@@ -29,7 +29,7 @@
   </head>
   <body class="snap-scroll">
     <nav class="navbar">
-      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" />Stan van Goor</div>
+      <div class="logo"><img src="https://media.licdn.com/dms/image/v2/D4E03AQGHCFIkX8VBdA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1725647091449?e=2147483647&v=beta&t=Xh_zDLO-pHISpGzLGcHFAYnahcSTWuNOCcuLefe6ZHY" alt="Profile" class="nav-profile-img" /><span class='nav-name'>Stan van Goor</span></div>
       <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
         <li><a href="index.html" data-i18n="nav-about">About me</a></li>

--- a/style.css
+++ b/style.css
@@ -701,28 +701,45 @@ a:visited {
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .navbar {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
     flex-wrap: wrap;
+  }
+
+  .nav-name,
+  .lang-toggle,
+  .theme-toggle {
+    display: none;
+  }
+
+  .nav-links.active + .lang-toggle,
+  .nav-links.active + .lang-toggle + .theme-toggle {
+    display: block;
+    width: 100%;
+    text-align: center;
+    order: 4;
   }
 
   .menu-toggle {
     display: block;
-    margin-left: auto;
+    order: 2;
   }
 
   .current-page {
     display: block;
     flex: 1;
     text-align: center;
+    order: 1;
   }
 
   .nav-links {
     display: none;
     width: 100%;
+    flex-basis: 100%;
     flex-direction: column;
     gap: 0.5rem;
     margin-top: 0.5rem;
+    order: 3;
   }
 
   .nav-links.active {


### PR DESCRIPTION
## Summary
- hide navbar name, language and theme buttons on small screens
- show them within the dropdown when menu is open
- keep profile image, current page title and menu icon side-by-side

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68418593caf483299bac922d7061ab56