### PR TITLE
Implement language dropdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,6 +66,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Language toggle
   const langToggle = document.getElementById("lang-toggle");
 
+  const flags = { en: "\ud83c\uddec\ud83c\udde7", nl: "\ud83c\uddf3\ud83c\uddf1" };
+  const languageNames = { en: "English", nl: "Nederlands" };
+
   let langHint;
   let themeHint;
 
@@ -215,7 +218,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
     if (langToggle) {
-      langToggle.textContent = lang === "nl" ? "🇬🇧" : "🇳🇱";
+      langToggle.textContent = flags[lang];
     }
   }
 
@@ -223,17 +226,41 @@ document.addEventListener("DOMContentLoaded", () => {
   applyTranslations(storedLang);
 
   if (langToggle) {
-    langToggle.setAttribute("title", "Switch language");
+    langToggle.setAttribute("title", "Select language");
     langHint = document.createElement("span");
     langHint.id = "lang-hint";
     langHint.className = "help-hint";
     langHint.textContent = "\ud83c\udf10";
     langToggle.after(langHint);
+
+    const langMenu = document.createElement("ul");
+    langMenu.id = "lang-menu";
+    langMenu.className = "lang-menu";
+    Object.keys(languageNames).forEach((code) => {
+      const li = document.createElement("li");
+      li.dataset.lang = code;
+      li.textContent = `${flags[code]} ${languageNames[code]}`;
+      langMenu.appendChild(li);
+    });
+    langHint.after(langMenu);
+
     langToggle.addEventListener("click", () => {
-      const newLang =
-        (localStorage.getItem("lang") || "en") === "en" ? "nl" : "en";
-      localStorage.setItem("lang", newLang);
-      applyTranslations(newLang);
+      langMenu.classList.toggle("open");
+    });
+
+    langMenu.addEventListener("click", (e) => {
+      const selected = e.target.getAttribute("data-lang");
+      if (selected) {
+        localStorage.setItem("lang", selected);
+        applyTranslations(selected);
+        langMenu.classList.remove("open");
+      }
+    });
+
+    document.addEventListener("click", (e) => {
+      if (!langToggle.contains(e.target) && !langMenu.contains(e.target)) {
+        langMenu.classList.remove("open");
+      }
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -130,6 +130,37 @@ a:visited {
   font-size: 1.2rem;
   cursor: pointer;
   margin-left: 1rem;
+  position: relative;
+}
+
+.lang-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: none;
+  z-index: 1001;
+}
+.dark .lang-menu {
+  background: rgba(0, 0, 0, 0.9);
+  border-color: #444;
+}
+.lang-menu li {
+  padding: 0.25rem 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.lang-menu li:hover {
+  background-color: var(--accent);
+  color: #fff;
+}
+.lang-menu.open {
+  display: block;
 }
 
 .menu-toggle {
@@ -748,6 +779,15 @@ a:visited {
   .lang-toggle,
   .theme-toggle {
     display: none;
+  }
+
+  .lang-menu {
+    position: static;
+    width: 100%;
+    border: none;
+    text-align: center;
+    margin-top: 0.5rem;
+    order: 5;
   }
 
   .nav-links.active + .lang-toggle,


### PR DESCRIPTION
## Summary
- show the current language flag
- add dropdown menu for selecting language
- style dropdown for mobile/desktop

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2e555908329b9767c78177d90f6