### PR TITLE
Add partner logo slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,20 @@
           <p class="menu-desc">Get in touch</p>
         </a>
       </section>
+      <div class="partner-bar">
+        <div class="partner-track">
+          <img src="https://via.placeholder.com/120x60?text=Logo+1" alt="Partner 1" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+2" alt="Partner 2" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+3" alt="Partner 3" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+4" alt="Partner 4" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+5" alt="Partner 5" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+1" alt="" aria-hidden="true" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+2" alt="" aria-hidden="true" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+3" alt="" aria-hidden="true" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+4" alt="" aria-hidden="true" />
+          <img src="https://via.placeholder.com/120x60?text=Logo+5" alt="" aria-hidden="true" />
+        </div>
+      </div>
       <section class="section light">
         <h2 data-i18n="experience-heading">Experience</h2>
         <p data-i18n="experience-text1">

--- a/style.css
+++ b/style.css
@@ -844,3 +844,42 @@ a:visited {
     height: 300px;
   }
 }
+
+/* Partner logo slider */
+.partner-bar {
+  background-color: #f3e9ff;
+  overflow: hidden;
+  padding: 1rem 0;
+}
+
+.dark .partner-bar {
+  background-color: #2d1b3a;
+}
+
+.partner-track {
+  display: flex;
+  width: max-content;
+  animation: partner-scroll 25s linear infinite;
+}
+
+.partner-track img {
+  height: 50px;
+  margin: 0 2rem;
+  width: auto;
+}
+
+@keyframes partner-scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@media (max-width: 768px) {
+  .partner-track img {
+    height: 40px;
+    margin: 0 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- show partner logo carousel below circle menu on landing page
- style new horizontal bar with smooth sliding animation

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684ac72e6e3c8329a2e8273eaddc3c23